### PR TITLE
Remove 100% width on container

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -8,7 +8,6 @@ author: Karan Sharma
 ----------------------------------------------------------*/
 .container {
   position: relative;
-  width: 100%;
   max-width: 960px;
   margin: 0 auto;
   padding: 0 10px;


### PR DESCRIPTION
100% width causes the container to overflow in some cases. auto is a better default.